### PR TITLE
Removing adding sinon import to test files

### DIFF
--- a/__testfixtures__/ember-sinon-sandbox-codemod/imports.added.once.input.js
+++ b/__testfixtures__/ember-sinon-sandbox-codemod/imports.added.once.input.js
@@ -1,4 +1,3 @@
-import sinon from 'sinon';
 import { moduleForAcceptance, test } from 'ember-qunit';
 
 moduleForAcceptance('foo', 'Acceptance | Foo', {

--- a/__testfixtures__/ember-sinon-sandbox-codemod/imports.added.once.output.js
+++ b/__testfixtures__/ember-sinon-sandbox-codemod/imports.added.once.output.js
@@ -1,4 +1,3 @@
-import sinon from 'sinon';
 import { moduleForAcceptance, test } from 'ember-qunit';
 
 moduleForAcceptance('foo', 'Acceptance | Foo', {});

--- a/__testfixtures__/ember-sinon-sandbox-codemod/sinon.sandbox.create.empty.beforeeach.output.js
+++ b/__testfixtures__/ember-sinon-sandbox-codemod/sinon.sandbox.create.empty.beforeeach.output.js
@@ -1,4 +1,3 @@
-import sinon from 'sinon';
 import { moduleForAcceptance, test } from 'ember-qunit';
 
 moduleForAcceptance('foo', 'Acceptance | Foo', {});

--- a/__testfixtures__/ember-sinon-sandbox-codemod/sinon.sandbox.create.nonempty.beforeeach.output.js
+++ b/__testfixtures__/ember-sinon-sandbox-codemod/sinon.sandbox.create.nonempty.beforeeach.output.js
@@ -1,4 +1,3 @@
-import sinon from 'sinon';
 import { moduleForAcceptance, test } from 'ember-qunit';
 
 moduleForAcceptance('foo', 'Acceptance | Foo', {

--- a/__testfixtures__/ember-sinon-sandbox-codemod/sinon.sandbox.restore.empty.aftereach.output.js
+++ b/__testfixtures__/ember-sinon-sandbox-codemod/sinon.sandbox.restore.empty.aftereach.output.js
@@ -1,4 +1,3 @@
-import sinon from 'sinon';
 import { moduleForAcceptance, test } from 'ember-qunit';
 
 moduleForAcceptance('foo', 'Acceptance | Foo', {});

--- a/__testfixtures__/ember-sinon-sandbox-codemod/sinon.sandbox.restore.nonempty.aftereach.output.js
+++ b/__testfixtures__/ember-sinon-sandbox-codemod/sinon.sandbox.restore.nonempty.aftereach.output.js
@@ -1,4 +1,3 @@
-import sinon from 'sinon';
 import { moduleForAcceptance, test } from 'ember-qunit';
 
 moduleForAcceptance('foo', 'Acceptance | Foo', {

--- a/ember-sinon-sandbox-codemod.js
+++ b/ember-sinon-sandbox-codemod.js
@@ -85,24 +85,8 @@ module.exports = function(file, api) {
     }
   }
 
-  function addSinonImport() {
-    let body = root.get().value.program.body;
-    let importDeclaration = root.find(j.ImportDeclaration, {
-      source: { value: 'sinon' },
-    });
-
-    if (importDeclaration.length === 0) {
-      importDeclaration = j.importDeclaration(
-        [j.importDefaultSpecifier(j.identifier('sinon'))],
-        j.literal('sinon')
-      );
-      body.unshift(importDeclaration);
-    }
-  }
-
   removeSandboxCreate();
   removeSandboxRestore();
-  addSinonImport();
 
   return root.toSource({
     quote: 'single',


### PR DESCRIPTION
Since we're using `ember-sinon-sandbox`, we don't need to add explicit imports.